### PR TITLE
Add nsp check to circle ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 
 dependencies:
   pre:
-    - npm i -g get-firefox geckodriver
+    - npm i -g get-firefox geckodriver nsp
     - get-firefox --platform linux --extract --target /home/ubuntu/send
 
 deployment:
@@ -33,3 +33,4 @@ test:
   override:
     - npm run lint
     - npm test
+    - nsp check


### PR DESCRIPTION
Completes one more checkbox on the security checklist.
Note that this runs on Circle-CI only, and not on any local scripts or local dependency or commit hooks.