### PR TITLE
Stop ESLint from linting the /public/ directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
-public/upload.js
-public/download.js
-public/webcrypto-shim.js
+public
 test/frontend/bundle.js
 firefox

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build:version": "node scripts/version",
     "build:l10n": "cp node_modules/l20n/dist/web/l20n.min.js public",
     "dev": "npm run build && npm start",
-    "format": "prettier '{frontend/src/,scripts/,server/,test/}*.js' 'public/*.css' --single-quote --write",
+    "format": "prettier '{frontend/src/,scripts/,server/,test/**/}*.js' 'public/*.css' --single-quote --write",
     "lint": "npm-run-all lint:*",
     "lint:css": "stylelint 'public/*.css'",
     "lint:js": "eslint .",

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -19,3 +19,5 @@ rules:
   mocha/no-pending-tests: error
   mocha/no-return-and-callback: warn
   mocha/no-skipped-tests: error
+
+  no-console: off # ¯\_(ツ)_/¯


### PR DESCRIPTION
The /public/ directory is an odd mix of generated and static files. We don't need to ESLint anything in there, and it was blowing up my computer because of minified l20n files that were being copied from node_modules, and an old bundle file.