### PR TITLE
Update download progress bar color

### DIFF
--- a/frontend/src/download.js
+++ b/frontend/src/download.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
   $('#dl-progress').circleProgress({
     value: 0.0,
     startAngle: -Math.PI / 2,
-    fill: '#00C8D7',
+    fill: '#3B9DFF',
     size: 158,
     animation: { duration: 300 }
   });


### PR DESCRIPTION
Fixes #205 

Took the cheap way out and just copied the color. We could optionally copy the entire circle progress bar config and export it in ./utils.js so all the settings could be shared between upload and download (so we don't have to worry about the animation duration and sizes getting out of sync, etc).
