### PR TITLE
fix: Don`t allow upload when not on the upload page.

### DIFF
--- a/frontend/src/upload.js
+++ b/frontend/src/upload.js
@@ -133,6 +133,12 @@ $(document).ready(function() {
   // on file upload by browse or drag & drop
   function onUpload(event) {
     event.preventDefault();
+
+    // don't allow upload if not on upload page
+    if ($('#page-one').attr('hidden')){
+      return;
+    }
+
     storage.totalUploads += 1;
 
     let file = '';


### PR DESCRIPTION
This was mostly fixed in a previous PR that didn't allow drag and drop on any page other than the first. This to fix the edge case reproduced by:
- click the upload button, 
- drag and drop a file instead
- then click and select a second file and click upload

Fixes #160.