### PR TITLE
use CIRCLE_TAG as version.json version if present

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -14,7 +14,7 @@ const filename = path.join(__dirname, '..', 'public', 'version.json');
 const filedata = {
   commit,
   source: pkg.homepage,
-  version: pkg.version
+  version: process.env.CIRCLE_TAG || pkg.version
 };
 
 fs.writeFileSync(filename, JSON.stringify(filedata, null, 2) + '\n');


### PR DESCRIPTION
This ought to fix inconsistency between the tag version and version.json version for tagged builds

@pdehaan @relud r?

fixes #298