### PR TITLE
support v 50 and 51 by not allowing const in loops

### DIFF
--- a/frontend/src/upload.js
+++ b/frontend/src/upload.js
@@ -80,6 +80,7 @@ $(document).ready(function() {
   if (files.length === 0) {
     toggleHeader();
   } else {
+    // eslint-disable-next-line prefer-const
     for (let index in files) {
       const id = files[index].fileId;
       //check if file still exists before adding to list

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,5 +1,6 @@
 function arrayToHex(iv) {
   let hexStr = '';
+  // eslint-disable-next-line prefer-const
   for (let i in iv) {
     if (iv[i] < 16) {
       hexStr += '0' + iv[i].toString(16);


### PR DESCRIPTION
the 
`  prefer-const: error` 
rule in eslint forces `const` in for loops, But firefox 50 and 51 break when this is enforced. Since Test pilot supports v50+ I think we should remove this from our code and lint rules. 
(I could not find a eslint rule related to this that would allow `let` in loops, so have removed it altogether)
re: #334