### PR TITLE
Remove duplicate entities in localized FTL files

### DIFF
--- a/public/locales/cs/send.ftl
+++ b/public/locales/cs/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Kopírovat URL
 expiryFileList = Platnost vyprší za
 deleteFileList = Smazat
 nevermindButton = Nevadí
-deleteButtonHover
-    .title = Smazat
-copyUrlHover
-    .title = Kopírovat URL
 legalHeader = Podmínky a ochrana soukromí
 legalNoticeTestPilot = Firefox Send je ve fázi experimentu projektu Test Pilot a platí tak pro něj stejné <a>Podmínky používání</a> a <a>Zásady ochrany soukromí</a>. Více o tomto experimentu a sbíraných datech se dozvíte <a>zde</a>.
 legalNoticeMozilla = Používání webové služby Firefox Send se řídí <a>Zásadami ochrany soukromí</a> a <a>Podmínkami používání</a> webových stránek Mozilly.

--- a/public/locales/cy/send.ftl
+++ b/public/locales/cy/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Copïo URL
 expiryFileList = Daw i ben ymhen
 deleteFileList = Dileu
 nevermindButton = Dim ots
-deleteButtonHover
-    .title = Dileu
-copyUrlHover
-    .title = Copïo'r URL
 legalHeader = Amodau a Phreifatrwydd
 legalNoticeTestPilot = Ar hyn o mae Firefox Send yn arbrawf  o fewn rhaglen Test Pilot ac yn destun <a>Amodau Gwasanaeth</a> a <a>Hysbysiad Preifatrwydd</a> Test Pilot . Gallwch ddysgu rhagor am yr arbrawf a'i gasglu data <a>yma</a>.
 legalNoticeMozilla = Mae'r defnydd o wefan Firefox Send hefyd yn destun <a>Hysbysiad Preifatrwydd Gwefannau</a> ac <a>Amodau Defnydd Gwefannau</a> Mozilla.

--- a/public/locales/de/send.ftl
+++ b/public/locales/de/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Adresse kopieren
 expiryFileList = Läuft ab in
 deleteFileList = Löschen
 nevermindButton = Egal
-deleteButtonHover
-    .title = Löschen
-copyUrlHover
-    .title = Adresse kopieren
 legalHeader = Nutzungsbedingungen und Datenschutz
 legalNoticeTestPilot = Firefox Send ist aktuell ein Test-Pilot-Experiment und unterliegt den <a>Nutzungsbedingungen</a> und dem <a>Datenschutzhinweis</a> von Test Pilot. Mehr über diese Experiment und die Daten, die es sammelt, erfahren Sie <a>hier</a>.
 legalNoticeMozilla = Die Nutzung der Website von Firefox Send unterliegt außerdem Mozillas <a>Datenschutzhinweis für Websites</a> und <a>Nutzungsbedingungen für Websites</a>.

--- a/public/locales/dsb/send.ftl
+++ b/public/locales/dsb/send.ftl
@@ -74,13 +74,9 @@ copyFileList = URL kopěrowaś
 expiryFileList = Spadnjo za
 deleteFileList = Wulašowaś
 nevermindButton = Wšojadno
-deleteButtonHover
-    .title = Wulašowaś
-copyUrlHover
-    .title = URL kopěrowaś
 legalHeader = Wuměnjenja a priwatnosć
 legalNoticeTestPilot = Firefox jo tuchylu eksperiment Test Pilot, a pódlažy <a>wužywańskim wuměnjenjam</a> a <a>pokazce priwatnosći</a> Test Pilot. Wěcej wó toś tom eksperimenśe a daty, kótarež gromaźi, <a>how</a> zgónijośo.
-legalNoticeMozilla = Teke wužywanje websedła Firefox Send <a>pokazce priwatnosći za websedła</a> a <a>wužywańskim wuměnjenjam za websedła</a> Mozilla pódlažy. 
+legalNoticeMozilla = Teke wužywanje websedła Firefox Send <a>pokazce priwatnosći za websedła</a> a <a>wužywańskim wuměnjenjam za websedła</a> Mozilla pódlažy.
 deletePopupText = Toś tu dataju lašowaś?
 deletePopupYes = Jo
 deletePopupCancel = Pśetergnuś

--- a/public/locales/el/send.ftl
+++ b/public/locales/el/send.ftl
@@ -60,11 +60,7 @@ copyFileList = Αντιγραφή URL
 // expiryFileList is used as a column header
 expiryFileList = Λήγει σε
 deleteFileList = Διαγραφή
-nevermindButton = Μην ανησυχείτε 
-deleteButtonHover
-    .title = Διαγραφή
-copyUrlHover
-    .title = Αντιγραφή URL
+nevermindButton = Μην ανησυχείτε
 legalHeader = Όροι & απόρρητο
 deletePopupText = Διαγραφή αρχείου;
 deletePopupYes = Ναι

--- a/public/locales/es-AR/send.ftl
+++ b/public/locales/es-AR/send.ftl
@@ -65,10 +65,6 @@ copyFileList = Copiar URL
 // expiryFileList is used as a column header
 expiryFileList = Expira en
 deleteFileList = Borrar
-deleteButtonHover
-    .title = Borrar
-copyUrlHover
-    .title = Copiar URL
 legalHeader = Términos y privacidad
 deletePopupText = ¿Borrar este archivo?
 deletePopupYes = Si

--- a/public/locales/es-ES/send.ftl
+++ b/public/locales/es-ES/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Copiar URL
 expiryFileList = Caduca en
 deleteFileList = Eliminar
 nevermindButton = Da igual
-deleteButtonHover
-    .title = Eliminar
-copyUrlHover
-    .title = Copiar URL
 legalHeader = Términos y privacidad
 legalNoticeTestPilot = Firefox Send sigue siendo un experimento de Test Pilot y está sujero a las <a>Condiciones del servicio</a> y al <a>Aviso de privacidad</a> de Test Pilot.
 legalNoticeMozilla = El uso de la página de Firefox Send también está sujeto al <a>Aviso de privacidad sobre sitios web</a> y a los <a>Términos de uso sobre sitios web</a>.

--- a/public/locales/fr/send.ftl
+++ b/public/locales/fr/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Copier le lien
 expiryFileList = Expire dans
 deleteFileList = Supprimer
 nevermindButton = Non merci
-deleteButtonHover
-    .title = Supprimer
-copyUrlHover
-    .title = Copier le lien
 legalHeader = Confidentialité et conditions d’utilisation
 legalNoticeTestPilot = Firefox Send est actuellement une expérience Test Pilot, et en tant que tel est soumis aux <a>conditions d’utilisation</a> et à la <a>politique de confidentialité</a> de Test Pilot. Vous pouvez en apprendre plus sur cette expérience et sur la collecte de données <a>ici</a>.
 legalNoticeMozilla = L’utilisation du site web Firefox Send est aussi soumise à <a>l’avis de confidentialité relatif aux sites Web</a> ainsi qu’aux <a>conditions d’utilisation des sites Web</a> de Mozilla.

--- a/public/locales/fy-NL/send.ftl
+++ b/public/locales/fy-NL/send.ftl
@@ -74,10 +74,6 @@ copyFileList = URL kopiearje
 expiryFileList = Ferrint oer
 deleteFileList = Fuortsmite
 nevermindButton = Lit mar
-deleteButtonHover
-    .title = Fuortsmite
-copyUrlHover
-    .title = URL kopiearje
 legalHeader = Betingsten en privacy
 legalNoticeTestPilot = Firefox Send is op dit stuit in Test Pilot-eksperimint en falt ûnder de <a>Betingsten</a> en <a>Privacybelied</a> fan Test Pilot. Mear ynformaasje oer dit eksperimint en de gegevenssamling stiet<a>hjir</a>.
 legalNoticeMozilla = Gebrûk fan de Firefox Send-website falt ek ûnder it <a>Websites Privacybelied</a> en <a>Websites Gebrûksbetingsten</a> fan Mozilla.

--- a/public/locales/hsb/send.ftl
+++ b/public/locales/hsb/send.ftl
@@ -74,13 +74,9 @@ copyFileList = URL kopěrować
 expiryFileList = Spadnje za
 deleteFileList = Zhašeć
 nevermindButton = Wšojedne
-deleteButtonHover
-    .title = Zhašeć
-copyUrlHover
-    .title = URL kopěrować
 legalHeader = Wuměnjenja a priwatnosć
 legalNoticeTestPilot = Firefox je tuchwilu eksperiment Test Pilot, a podleži <a>wužiwanskim wuměnjenjam</a> a <a>pokazce priwatnosće</a> Test Pilot. Wjace wo tutym eksperimenće a daty, kotrež hromadźi, <a>tu</a> zhoniće.
-legalNoticeMozilla = Tež wužiwanje websydła Firefox Send <a>pokazce priwatnosće za websydła</a> a <a>wužiwanskim wuměnjenjam za websydła</a> Mozilla podleži. 
+legalNoticeMozilla = Tež wužiwanje websydła Firefox Send <a>pokazce priwatnosće za websydła</a> a <a>wužiwanskim wuměnjenjam za websydła</a> Mozilla podleži.
 deletePopupText = Tutu dataju zhašeć?
 deletePopupYes = Haj
 deletePopupCancel = Přetorhnyć

--- a/public/locales/hu/send.ftl
+++ b/public/locales/hu/send.ftl
@@ -66,7 +66,7 @@ linkExpiredAlt
 expiredPageHeader = Ez a hivatkozás lejárt, vagy sosem létezett!
 notSupportedHeader = A böngésző nem támogatott.
 // Firefox Send is a brand name and should not be localized.
-notSupportedDetail = Sajnos ez a böngésző nem támogatja a Firefox Send alapját képező webes technológiát. Egy másik böngészőben kell megpróbálnia. Mi a Firefoxot javasoljuk! 
+notSupportedDetail = Sajnos ez a böngésző nem támogatja a Firefox Send alapját képező webes technológiát. Egy másik böngészőben kell megpróbálnia. Mi a Firefoxot javasoljuk!
 downloadFirefoxButtonSub = Ingyenes letöltés
 uploadedFile = Fájl
 copyFileList = URL másolása
@@ -74,10 +74,6 @@ copyFileList = URL másolása
 expiryFileList = Lejár:
 deleteFileList = Törlés
 nevermindButton = Mindegy
-deleteButtonHover
-    .title = Törlés
-copyUrlHover
-    .title = URL másolása
 legalHeader = Feltételek és adatvédelem
 legalNoticeTestPilot = A Firefox Send pillanatnyilag egy Tesztpilóta kísérlet, és a <a>Szolgáltatási feltételek</a> valamint az <a>Adatvédelmi nyilatkozat</a> vonatkozik rá. Többet tudhat meg a kísérletről, és az adatgyűjtéséről <a>itt</a>.
 legalNoticeMozilla = A Firefox Send weboldal használatakor a Mozilla <a>Webhelyekre vonatkozó adatvédelmi nyilatkozata</a> és a <a>Weboldalak felhasználási feltételei</a> is vonatkoznak Önre.

--- a/public/locales/it/send.ftl
+++ b/public/locales/it/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Copia indirizzo
 expiryFileList = Scade in
 deleteFileList = Elimina
 nevermindButton = No, grazie
-deleteButtonHover
-    .title = Elimina
-copyUrlHover
-    .title = Copia indirizzo
 legalHeader = Termini di utilizzo e privacy
 legalNoticeTestPilot = Firefox Send è attualmente un esperimento di Test Pilot ed è soggetto alle <a>Condizioni di utilizzo</a> e all’<a>Informativa sulla privacy</a> di Test Pilot. Per ulteriori informazioni su questo esperimento e i dati raccolti, consulta <a>questa pagina<a>.
 legalNoticeMozilla = L’utilizzo del sito di Firefox Send è soggetto all’<a>Informativa sulla privacy</a> e le <a>Condizioni di utilizzo</a> dei siti web Mozilla.

--- a/public/locales/ja/send.ftl
+++ b/public/locales/ja/send.ftl
@@ -74,10 +74,6 @@ copyFileList = URL をコピー
 expiryFileList = 有効期限:
 deleteFileList = 削除
 nevermindButton = 気にしないでください
-deleteButtonHover
-    .title = 削除
-copyUrlHover
-    .title = URL をコピー
 legalHeader = 利用規約とプライバシー
 legalNoticeTestPilot = Firefox Send は今のところ Test Pilot 実験のひとつであり、Test Pilot <a>利用規約</a> と <a>プライバシー通知</a> が適用されます。この実験とそのデータ収集に関する詳細は <a>こちら</a> をご覧ください。
 legalNoticeMozilla = Firefox Send のサイトの利用には、Mozilla の <a>ウェブサイトプライバシー通知</a> と <a>ウェブサイト利用規約</a> も適用されます。

--- a/public/locales/kab/send.ftl
+++ b/public/locales/kab/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Nɣel URL
 expiryFileList = Ad ifak di
 deleteFileList = Kkes
 nevermindButton = Wicqa
-deleteButtonHover
-    .title = Kkes
-copyUrlHover
-    .title = Nɣel URL.
 legalHeader = Tiwtilin &tabaḍnit
 legalNoticeTestPilot = Firefox Send yettwasekyad akka tura am tarmit Test Pilot, ihi ad yili daw n <a>n tewtilin n useqdec </a> n  Test Pilot akked <a>Tasertit n tbaḍnit</a>. Tzemreḍ ad teẓreḍ ugar ɣeef tarmit-agi akked ulqaḍ n isefka<a> dagihere</a>.
 legalNoticeMozilla = Aseqdec n usmel n Firefox Send yella daw n <a> ilugan tbaḍnit n yismal web </a> n Mozilla akked <a> Tiwtilin n useqdec n yismal Web</a> n Mozilla.

--- a/public/locales/ms/send.ftl
+++ b/public/locales/ms/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Salin URL
 expiryFileList = Luput Pada
 deleteFileList = Padam
 nevermindButton = Tak apalah
-deleteButtonHover
-    .title = Padam
-copyUrlHover
-    .title = Salin URL
 legalHeader = Terma & Privasi
 legalNoticeTestPilot = Firefox Send adalah eksperimen Ujian Perintis, dan tertakluk kepada <a>Terma Perkhidmatan</a> dan <a>Privacy Notice</a> Ujian Perintis. Anda boleh ketahui selanjutnya perihal eksperimen ini dan pengumpulan data <a>di sini</a>.
 legalNoticeMozilla = Penggunaan laman web Firefox Send juga tertakluk kepada <a>Notis Privasi Laman web</a> dan <a>Terma Penggunaan Laman web</a> Mozilla.

--- a/public/locales/nb-NO/send.ftl
+++ b/public/locales/nb-NO/send.ftl
@@ -62,10 +62,6 @@ copyFileList = Kopier URL
 expiryFileList = Utløper om
 deleteFileList = Slett
 nevermindButton = Glem det
-deleteButtonHover
-    .title = Slett
-copyUrlHover
-    .title = Kopier URL
 legalHeader = Vilkår og personvern
 deletePopupText = Slette denne filen?
 deletePopupYes = Ja

--- a/public/locales/pt-BR/send.ftl
+++ b/public/locales/pt-BR/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Copiar URL
 expiryFileList = Expira em
 deleteFileList = Excluir
 nevermindButton = Esqueça
-deleteButtonHover
-    .title = Excluir
-copyUrlHover
-    .title = Copiar URL
 legalHeader = Termos e privacidade
 legalNoticeTestPilot = Firefox Send é um experimento do Test Pilot, e sujeito aos <a>Termos de Serviço</a> e <a>Políticas de Privacidade</a> do Test Pilot. Você pode aprender mais sobre esse experimento e a coleta de dados <a>aqui</a>.
 legalNoticeMozilla = O uso do site Firefox Send também está sujeito a <a>Política de Privacidade</a> e <a>Websites Terms of Use</a> da Mozilla.

--- a/public/locales/pt-PT/send.ftl
+++ b/public/locales/pt-PT/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Copiar URL
 expiryFileList = Expira em
 deleteFileList = Apagar
 nevermindButton = Esquecer
-deleteButtonHover
-    .title = Apagar
-copyUrlHover
-    .title = Copiar URL
 legalHeader = Termos e privacidade
 legalNoticeTestPilot = O Firefox Send é atualmente uma experiência do Test Pilot, e sujeita aos <a>Termos de serviço</a> e <a>Aviso de privacidade</a> do Test Pilot. Pode saber mais acerca desta experiência e a sua recolha de dados <a>aqui</a>.
 legalNoticeMozilla = A utilização do website do Firefox Send está também sujeita ao <a>Aviso de privacidade dos websites</a> e <a>Termos de serviço dos websites</a> da Mozilla.

--- a/public/locales/sk/send.ftl
+++ b/public/locales/sk/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Kopírovať adresu URL
 expiryFileList = Platnosť vyprší
 deleteFileList = Odstrániť
 nevermindButton = Zrušiť
-deleteButtonHover
-    .title = Odstrániť
-copyUrlHover
-    .title = Skopírovať adresu URL
 legalHeader = Podmienky používania a súkromie
 legalNoticeTestPilot = Firefox Send je v súčasnosti experimentom projektu Test Pilot a vzťahujú sa naň <a>podmienky používania</a> a <a>zásady ochrany súkromia</a> Test Pilotu. Viac sa o zbieraní údajov experimentami dozviete <a>tu</a>.
 legalNoticeMozilla = Na použitie webovej stránky služby Firefox Send sa vzťahujú <a>zásady ochrany súkromia na webových stránkach</a> a <a>podmienky použitia webových stránok</a> Mozilly.

--- a/public/locales/sl/send.ftl
+++ b/public/locales/sl/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Kopiraj spletni naslov
 expiryFileList = Poteče
 deleteFileList = Izbriši
 nevermindButton = Pozabi
-deleteButtonHover
-    .title = Izbriši
-copyUrlHover
-    .title = Kopiraj spletni naslov
 legalHeader = Pogoji in zasebnost
 legalNoticeTestPilot = Firefox Send je trenutno poskus projekta Test Pilot ter zanj veljajo <a>pogoji uporabe</a> in <a>obvestilo o zasebnosti</a> Test Pilota. Več o tem poskusu in njegovem zbiranju podatkov lahko izveste <a>tukaj</a>.
 legalNoticeMozilla = Za uporabo spletne strani Firefox Send veljajo Mozillini <a>obvestilo o zasebnosti za spletne strani</a> in <a>pogoji uporabe spletnih strani</a>.

--- a/public/locales/sv-SE/send.ftl
+++ b/public/locales/sv-SE/send.ftl
@@ -74,10 +74,6 @@ copyFileList = Kopiera URL
 expiryFileList = Upphör
 deleteFileList = Ta bort
 nevermindButton = Glöm det
-deleteButtonHover
-    .title = Ta bort
-copyUrlHover
-    .title = Kopiera URL
 legalHeader = Villkor och sekretess
 legalNoticeTestPilot = Firefox Send är för närvarande ett Test Pilot experiment och omfattas av Test Pilots <a>användarvillkor</a> och <a>sekretesspolicy</a>. Du kan läsa dig mer om detta experiment och dess datainsamling <a>här</a>.
 legalNoticeMozilla = Användning av webbplatsen för Firefox Send är också föremål för Mozillas <a>sekretesspolicy för webbplatser</a> och <a>användarvillkor för webbplatser</a>.

--- a/public/locales/zh-CN/send.ftl
+++ b/public/locales/zh-CN/send.ftl
@@ -74,10 +74,6 @@ copyFileList = 复制网址
 expiryFileList = 过期时间
 deleteFileList = 删除
 nevermindButton = 没关系
-deleteButtonHover
-    .title = 删除
-copyUrlHover
-    .title = 复制网址
 legalHeader = 条款和隐私
 legalNoticeTestPilot = Firefox Send 目前是一个 Test Pilot 实验，并遵守 Test Pilot <a>服务条款</a>和<a>隐私声明</a>。您可以在<a>这里</a>了解此实验及数据收集的有关信息。
 legalNoticeMozilla = 使用 Firefox Send 网站亦受到 Mozilla <a>网站隐私声明</a>和<a>网站使用条款</a>的约束。

--- a/public/locales/zh-TW/send.ftl
+++ b/public/locales/zh-TW/send.ftl
@@ -74,10 +74,6 @@ copyFileList = 複製網址
 expiryFileList = 失效於
 deleteFileList = 刪除
 nevermindButton = 沒關係
-deleteButtonHover
-    .title = 刪除
-copyUrlHover
-    .title = 複製網址
 legalHeader = 使用條款及隱私權
 legalNoticeTestPilot = Firefox Send 目前是一個 Test Pilot 實驗，依照 Test Pilot 的<a>服務條款</a>及<a>隱私權公告</a>提供服務。您可以在<a>此處</a>了解實驗內容，以及所收集資料的詳細資訊。
 legalNoticeMozilla = 使用 Firefox Send 網站時，亦受到 Mozilla 的<a>網站隱私權公告</a>以及<a>網站使用條款</a>約束。


### PR DESCRIPTION
Removing trailing spaces is irrelevant in this context (they should have one)