### PR TITLE
revert the IE fix to fix footer on chrome

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -21,7 +21,6 @@ body {
   flex-direction: column;
   margin: 0;
   min-height: 100vh;
-  height: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
The previous commit was to fix an IE issue, but it caused the footer to float over content on Chrome.

This worked for me, but maybe there's a better way?