### PR TITLE
Add ESLint no-alert shame rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,6 +21,7 @@ rules:
 
   eol-last: [error, always]
   eqeqeq: error
+  no-alert: warn
   no-console: warn
   no-path-concat: error
   no-unused-vars: [error, {argsIgnorePattern: "^_|err|event|next|reject"}]


### PR DESCRIPTION
`alert()` is a bit gross. So adding ESLint rule that warns on usage so we can eventually be shamed into a better UI solution (since `alert()` and `prompt()` and `confirm()` can eventually be dismissed by the user with a "stop doing this" option -- which would be some bad UX).

```sh
$ git grep "alert" frontend/src

frontend/src/upload.js:          alert(str);
frontend/src/upload.js:        .then(alert);
```