### PR TITLE
fix percentage view on mobile layout

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -389,7 +389,6 @@ tbody {
   letter-spacing: -0.78px;
   font-family: 'Segoe UI', 'SF Pro Text', sans-serif;
   top: 53px;
-  left: 246.75px;
   width: 98.5px;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/public/main.css
+++ b/public/main.css
@@ -389,7 +389,8 @@ tbody {
   letter-spacing: -0.78px;
   font-family: 'Segoe UI', 'SF Pro Text', sans-serif;
   top: 53px;
-  width: 98.5px;
+  left: 50%;
+  transform: translateX(-50%);
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;


### PR DESCRIPTION
Percentage number doesn't fit in the middle when using mobile browser, chrome, firefox and safari on desktop, this commit is simple solution.

**Before**

<img src="https://user-images.githubusercontent.com/2667489/28877753-80cbf93c-77c7-11e7-9dad-e702d38718b7.png" height="500px">

**After**
<img src="https://user-images.githubusercontent.com/2667489/28877759-84b39690-77c7-11e7-9882-c39b5431e6d9.png" height="500px">
