### PR TITLE
Adjust hover behavior on send-logo (#382)

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -39,6 +39,11 @@ body {
   align-items: center;
 }
 
+.send-logo h1:hover {
+  color: #0297f8;
+  transition: color 50ms;
+}
+
 .send-logo > a {
   display: flex;
   flex-direction: row;
@@ -67,7 +72,7 @@ body {
   transition: color 50ms;
 }
 
-.send-logo:hover a {
+.site-subtitle a:hover {
   color: #0297f8;
 }
 

--- a/public/main.css
+++ b/public/main.css
@@ -39,9 +39,12 @@ body {
   align-items: center;
 }
 
+.send-logo h1 {
+  transition: color 50ms;
+}
+
 .send-logo h1:hover {
   color: #0297f8;
-  transition: color 50ms;
 }
 
 .send-logo > a {


### PR DESCRIPTION
I adjusted highlight targets to `h1` and `a`. Now it looks like this:

![untitled](https://user-images.githubusercontent.com/14314532/28884826-0c569e30-77e6-11e7-9c10-1a28b9bbe359.gif)

Not quite sure if this fits the original design.