### PR TITLE
fix link that breaks download by opening in new tab

### DIFF
--- a/views/download.handlebars
+++ b/views/download.handlebars
@@ -35,5 +35,5 @@
     </div>
   </div>
 
-  <a class="send-new" data-l10n-id="sendYourFilesLink"></a>
+  <a class="send-new" data-l10n-id="sendYourFilesLink" target="_blank"></a>
 </div>


### PR DESCRIPTION
Fixes #398 