### PR TITLE
Add link to FAQ in unsupported view

### DIFF
--- a/public/locales/en-US/send.ftl
+++ b/public/locales/en-US/send.ftl
@@ -67,6 +67,7 @@ expiredPageHeader = This link has expired or never existed in the first place!
 notSupportedHeader = Your browser is not supported.
 // Firefox Send is a brand name and should not be localized.
 notSupportedDetail = Unfortunately this browser does not support the web technology that powers Firefox Send. You’ll need to try another browser. We recommend Firefox!
+notSupportedLink = Why is my browser not supported?
 notSupportedOutdatedDetail = Unfortunately this version of Firefox does not support the web technology that powers Firefox Send. You’ll need to update your browser.
 updateFirefox = Update Firefox
 downloadFirefoxButtonSub = Free Download

--- a/views/unsupported.handlebars
+++ b/views/unsupported.handlebars
@@ -8,6 +8,7 @@
     </a>
   {{else}}
     <div class="description" data-l10n-id="notSupportedDetail">Unfortunately this browser does not support the web technology that powers Firefox Send. You’ll need to try another browser. We recommend Firefox!</div>
+    <div class="description"><a href="https://github.com/mozilla/send/blob/master/docs/faq.md#why-is-my-browser-not-supported" data-l10n-id="notSupportedLink" target="_blank" rel="noopener noreferrer"></a></div>
     <a id="dl-firefox" href="https://www.mozilla.org/firefox/new/?scene=2" target="_blank">
       <img src="/resources/firefox_logo-only.svg" class="firefox-logo" alt="Firefox"/>
       <div class="unsupported-button-text">Firefox<br>

--- a/views/unsupported.handlebars
+++ b/views/unsupported.handlebars
@@ -8,7 +8,7 @@
     </a>
   {{else}}
     <div class="description" data-l10n-id="notSupportedDetail">Unfortunately this browser does not support the web technology that powers Firefox Send. You’ll need to try another browser. We recommend Firefox!</div>
-    <div class="description"><a href="https://github.com/mozilla/send/blob/master/docs/faq.md#why-is-my-browser-not-supported" data-l10n-id="notSupportedLink" target="_blank" rel="noopener noreferrer"></a></div>
+    <div class="description"><a href="https://github.com/mozilla/send/blob/master/docs/faq.md#why-is-my-browser-not-supported" data-l10n-id="notSupportedLink" target="_blank" rel="noopener noreferrer">Why is my browser not supported?</a></div>
     <a id="dl-firefox" href="https://www.mozilla.org/firefox/new/?scene=2" target="_blank">
       <img src="/resources/firefox_logo-only.svg" class="firefox-logo" alt="Firefox"/>
       <div class="unsupported-button-text">Firefox<br>


### PR DESCRIPTION
Just adds a link to the relevant FAQ bits, although we still incur an l10n hit since I had to add a string.
Totally looks like:

<img width="772" alt="firefox_send" src="https://user-images.githubusercontent.com/557895/28935755-69ed788a-783a-11e7-8ff0-8d7429453d47.png">

Fixes #377 