### PR TITLE
Prevent download button from being clicked multiple times

### DIFF
--- a/frontend/src/download.js
+++ b/frontend/src/download.js
@@ -42,6 +42,9 @@ $(document).ready(function() {
   });
   $('#download-btn').click(download);
   function download() {
+    // Disable the download button to avoid accidental double clicks.
+    $('#download-btn').attr('disabled', 'disabled');
+
     storage.totalDownloads += 1;
 
     const fileReceiver = new FileReceiver();


### PR DESCRIPTION
This seems to work locally for me, but it happens so quickly sometimes I have a hard time clicking fast enough.

Fixes #429 