### PR TITLE
Add a few missing strings from es-CL and tr locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "cy",
     "de",
     "dsb",
+    "el",
     "en-US",
+    "es-CL",
     "es-ES",
     "es-MX",
     "fr",
@@ -77,6 +79,8 @@
     "sl",
     "sr",
     "sv-SE",
+    "tr",
+    "uk",
     "zh-CN",
     "zh-TW"
   ],

--- a/public/locales/es-CL/send.ftl
+++ b/public/locales/es-CL/send.ftl
@@ -8,6 +8,7 @@ uploadPageLearnMore = Aprender más
 uploadPageDropMessage = Suelta tu archivo aquí para empezar a subirlo
 uploadPageSizeMessage = Para una operación más confiable, es mejor mantener el tamaño del archivo bajo 1 GB
 uploadPageBrowseButton = Selecciona un archivo en tu computador
+    .title = Selecciona un archivo en tu computador
 uploadPageMultipleFilesAlert = Subir múltiples archivos o una carpeta actualmente no es posible.
 uploadPageBrowseButtonTitle = Subir archivo
 uploadingPageHeader = Subiendo tu archivo
@@ -18,6 +19,7 @@ decryptingFile = Descifrando…
 notifyUploadDone = Tu subida ha terminado.
 uploadingPageMessage = Una vez que tu archivo sea subido podrás ajustar las opciones de expiración.
 uploadingPageCancel = Cancelar subida
+    .title = Cancelar subida
 uploadCancelNotification = Tu subida fue cancelada.
 uploadingPageLargeFileMessage = Este archivo es grande y puede tardar un rato en subir. ¡Aprovecha de hacer algo mientras!
 uploadingFileNotification = Notificarme cuando la subida sea completada.
@@ -28,11 +30,14 @@ uploadSuccessTimingHeader = El enlace a tu archivo expirará tras 1 descarga o e
 copyUrlFormLabelWithName = Copia y comparte el enlace para enviar tu archivo: { $filename }
 // Note: Title text for button should be the same.
 copyUrlFormButton = Copiar al portapapeles
+    .title = Copiar al portapapeles
 copiedUrl = ¡Copiado!
 // Note: Title text for button should be the same.
 deleteFileButton = Eliminar archivo
+    .title = Eliminar archivo
 // Note: Title text for button should be the same.
 sendAnotherFileLink = Enviar otro archivo
+    .title = Enviar otro archivo
 // Alternative text used on the download link/button (indicates an action).
 downloadAltText
     .alt = Descargar
@@ -42,13 +47,16 @@ downloadFileSize = ({ $size })
 downloadMessage = Tu amigo te está enviando un archivo con Firefox Send, un servicio que te permite compartir archivos con un enlace seguro, privado y cifrado que expira automáticamente para asegurar que tus cosas no queden en línea de por vida.
 // Text and title used on the download link/button (indicates an action).
 downloadButtonLabel = Descargar
+    .title = Descargar
 downloadNotification = Tu descarga se completó.
 downloadFinish = Descarga completa
 // Firefox Send is a brand name and should not be localized. Title text for button should be the same.
 sendYourFilesLink = Probar Firefox Send
+    .title = Probar Firefox Send
 downloadingPageProgress = Descargando { $filename } ({ $size })
 downloadingPageMessage = Por favor, deja esta pestaña abierta mientras recibimos tu archivo y lo desciframos.
-errorAltText = Error de subida
+errorAltText
+    .alt = Error de subida
 errorPageHeader = ¡Algo se fue a las pailas!
 errorPageMessage = Hubo un error al subir el archivo.
 errorPageLink = Enviar otro archivo

--- a/public/locales/tr/send.ftl
+++ b/public/locales/tr/send.ftl
@@ -30,9 +30,11 @@ uploadSuccessTimingHeader = Dosyanız 1 kez indirildikten veya 24 saat geçtikte
 copyUrlFormLabelWithName = { $filename } dosyanızı başkasına göndermek için aşağıdaki linki kopyalayın.
 // Note: Title text for button should be the same.
 copyUrlFormButton = Panoya kopyala
+    .title = Panoya kopyala
 copiedUrl = Kopyalandı!
 // Note: Title text for button should be the same.
 deleteFileButton = Dosyayı sil
+    .title = Dosyayı sil
 // Note: Title text for button should be the same.
 sendAnotherFileLink = Başka bir dosya daha gönder
     .title = Başka bir dosya daha gönder
@@ -50,6 +52,7 @@ downloadNotification = İndirme tamamlandı.
 downloadFinish = İndirme tamamlandı
 // Firefox Send is a brand name and should not be localized. Title text for button should be the same.
 sendYourFilesLink = Firefox Send’i deneyin
+    .title = Firefox Send’i deneyin
 downloadingPageProgress = { $filename } indiriliyor ({ $size })
 downloadingPageMessage = Dosyanız indirilip şifresi çözülürken lütfen bu sekmeyi açık bırakın.
 errorAltText


### PR DESCRIPTION
Fixing a few errors/warnings via ```compare-locales l10n.toml . `ls public/locales` ```.
This brings those locales up to 100%. Also added "el" and "uk" locales to `availableLanguages` array since they seem to be at 100% as well.