### PR TITLE
Increase mimimum node version to 8.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^3.4.1"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.2.0"
   },
   "homepage": "https://github.com/mozilla/send/",
   "license": "MPL-2.0",


### PR DESCRIPTION
This version has a useful protection against http header splitting

fixes #467