### PR TITLE
removed the file sha256 hash

### DIFF
--- a/frontend/src/download.js
+++ b/frontend/src/download.js
@@ -41,10 +41,6 @@ function download() {
     document.l10n.formatValue('decryptingFile').then(progress.setText);
   });
 
-  fileReceiver.on('hashing', () => {
-    document.l10n.formatValue('verifyingFile').then(progress.setText);
-  });
-
   fileReceiver
     .download()
     .catch(err => {

--- a/frontend/src/fileReceiver.js
+++ b/frontend/src/fileReceiver.js
@@ -45,7 +45,6 @@ class FileReceiver extends EventEmitter {
               resolve([
                 {
                   data: this.result,
-                  aad: meta.aad,
                   filename: meta.filename,
                   iv: meta.id
                 },
@@ -69,7 +68,6 @@ class FileReceiver extends EventEmitter {
               {
                 name: 'AES-GCM',
                 iv: hexToArray(fdata.iv),
-                additionalData: hexToArray(fdata.aad),
                 tagLength: 128
               },
               key,
@@ -78,26 +76,8 @@ class FileReceiver extends EventEmitter {
             .then(decrypted => {
               return Promise.resolve(decrypted);
             }),
-          fdata.filename,
-          hexToArray(fdata.aad)
+          decodeURIComponent(fdata.filename)
         ]);
-      })
-      .then(([decrypted, fname, proposedHash]) => {
-        this.emit('hashing');
-        return window.crypto.subtle
-          .digest('SHA-256', decrypted)
-          .then(calculatedHash => {
-            const integrity =
-              new Uint8Array(calculatedHash).toString() ===
-              proposedHash.toString();
-            if (!integrity) {
-              this.emit('unsafe', true);
-              return Promise.reject();
-            } else {
-              this.emit('safe', true);
-              return Promise.all([decrypted, decodeURIComponent(fname)]);
-            }
-          });
       });
   }
 }

--- a/frontend/src/upload.js
+++ b/frontend/src/upload.js
@@ -169,10 +169,6 @@ $(() => {
           });
         });
 
-        fileSender.on('hashing', () => {
-          document.l10n.formatValue('verifyingFile').then(progress.setText);
-        });
-
         fileSender.on('encrypting', () => {
           document.l10n.formatValue('encryptingFile').then(progress.setText);
         });

--- a/server/server.js
+++ b/server/server.js
@@ -225,7 +225,6 @@ app.post('/upload', (req, res, next) => {
   }
 
   if (
-    !meta.hasOwnProperty('aad') ||
     !meta.hasOwnProperty('id') ||
     !meta.hasOwnProperty('filename') ||
     !validateIV(meta.id)


### PR DESCRIPTION
This removes the sha256 hash of the unencrypted file from the data sent to the server.

Our future product requirements may require us to send other identifying data at some point. Upon such a change we'll update the site to describe the change.

Note: The file name is still sent unencrypted. Work on that is being tracked in #69