### PR TITLE
Sort contributors alphabetically to prevent churn

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,65 +1,78 @@
-Danny Coates
 Abhinav Adduri
-Daniela Arcese
-Peter deHaan
-Erica
-Francesco Lodolo
-Michael Wolf
-manxmensch
-Håvar Henriksen
-Rok Žerdin
-Mark Liang
-Théo Chevalier
-Fjoerfoks
-Marcelo Poli
-Erica Wright
-Matjaž Horvat
-Selim Şumlu
-Rodrigo
-Kohei Yoshino
-YFdyh000
-Juraj Cigáň
-Bjørn I
-Pin-guang Chen
-Maykon Chagas
-Weihang Lo
-ravmn
-Rhoslyn Prys
-Balázs Meskó
-Jordi Serratosa
-Michael Köhler
-Chuck Harmston
-Moḥend Belqasem
-Roberto Alvarado
-Emin Mastizada
-Tymur Faradzhev
-avelper
-Francesco Lodolo [:flod]
-Daniel Thorn
+Alexander Slovesnik
+Amin Mahmudian
 Andreas Pettersson
-John Gruen
-Wil Clouser
-Марко Костић (Marko Kostić)
-eljuno
-Sahithi
-You-Wen Liang (Mark)
-Ton
+Balázs Meskó
+Bjørn I
+Boopesh Mahendran
+Chuck Harmston
+Cynthia Pereira
+Daniel Thorn
+Daniela Arcese
+Danny Coates
+Emin Mastizada
+Erica
+Erica Wright
+Fjoerfoks
+Francesco Lodolo
+Francesco Lodolo [:flod]
+Gautam krishna.R
+Håvar Henriksen
+Jim Spentzos
 Johann-S
-ariestiyansyah
-dgadelha
-erdem cobanoglu
-goofy
+John Gruen
+Jordi Serratosa
+Juraj Cigáň
+Kohei Yoshino
+Lan Glad
+Luna Jernberg
+Marcelo Poli
+Marco Aurélio
+Mark Liang
+Matjaž Horvat
+Maykon Chagas
+Michael Köhler
+Michael Wolf
 Michal Stanke
 Michal Vašíček
-Alexander Slovesnik
-Marco Aurélio
-Cynthia Pereira
+Moḥend Belqasem
+Nicholas Skinsacos
+Peter deHaan
+Pierre Neter
+Pin-guang Chen
+Rhoslyn Prys
 Rizky Ariestiyansyah
-Jim Spentzos
-xcffl
+Roberto Alvarado
+Rodrigo
+Rok Žerdin
+Sahithi
 Sairam Raavi
 Sandro
-Lan Glad
+Selim Şumlu
+Slimane Amiri
+Théo Chevalier
 Tomáš Zelina
-Μιχάλης
+Ton
+Tymur Faradzhev
 Victor Bychek
+Weihang Lo
+Wil Clouser
+YFdyh000
+You-Wen Liang (Mark)
+alex_mayorga
+ariestiyansyah
+avelper
+dgadelha
+ehuggett
+eljuno
+erdem cobanoglu
+gautamkrishnar
+goofy
+hi
+kenrick95
+manxmensch
+ravmn
+siparon
+xcffl
+Μιχάλης
+Марко Костић (Marko Kostić)

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "build:js": "webpack -p",
     "build:version": "node scripts/version",
     "build:vendor": "cp node_modules/l20n/dist/web/l20n.min.js node_modules/babel-polyfill/dist/polyfill.min.js public",
-    "contributors": "git shortlog -s -n | awk -F\\t '{print $2}' > CONTRIBUTORS",
+    "contributors": "git shortlog -s | awk -F\\t '{print $2}' > CONTRIBUTORS",
     "dev": "npm run build && npm start",
     "format": "prettier '{frontend/src/,scripts/,server/,test/**/!(bundle)}*.js' 'public/*.css' --single-quote --write",
     "get-prod-locales": "node scripts/get-prod-locales",


### PR DESCRIPTION
Adding latest contributors and changing sort order from number-of-commits to contributor name, to prevent needless. Should hopefully make diffs a bit easier to eyeball.