### PR TITLE
make the site mostly work when cookies (localStorage) are disabled

### DIFF
--- a/frontend/src/download.js
+++ b/frontend/src/download.js
@@ -2,7 +2,7 @@ const { Raven } = require('./common');
 const FileReceiver = require('./fileReceiver');
 const { bytes, notify, gcmCompliant } = require('./utils');
 const Storage = require('./storage');
-const storage = new Storage(localStorage);
+const storage = new Storage();
 const links = require('./links');
 const metrics = require('./metrics');
 const progress = require('./progress');
@@ -87,6 +87,7 @@ function download() {
       a.download = fname;
       document.body.appendChild(a);
       a.click();
+      URL.revokeObjectURL(downloadUrl);
     })
     .catch(err => {
       Raven.captureException(err);

--- a/frontend/src/metrics.js
+++ b/frontend/src/metrics.js
@@ -1,6 +1,13 @@
 const testPilotGA = require('testpilot-ga/src/TestPilotGA');
 const Storage = require('./storage');
-const storage = new Storage(localStorage);
+const storage = new Storage();
+
+let hasLocalStorage = false;
+try {
+  hasLocalStorage = !!localStorage;
+} catch (e) {
+  // don't care
+}
 
 const analytics = new testPilotGA({
   an: 'Firefox Send',
@@ -18,7 +25,10 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function sendEvent() {
-  return analytics.sendEvent.apply(analytics, arguments).catch(() => 0);
+  return (
+    hasLocalStorage &&
+    analytics.sendEvent.apply(analytics, arguments).catch(() => 0)
+  );
 }
 
 function urlToMetric(url) {

--- a/frontend/src/storage.js
+++ b/frontend/src/storage.js
@@ -1,8 +1,38 @@
 const { isFile } = require('./utils');
 
+class Mem {
+  constructor() {
+    this.items = new Map();
+  }
+
+  get length() {
+    return this.items.size;
+  }
+
+  getItem(key) {
+    return this.items.get(key);
+  }
+
+  setItem(key, value) {
+    return this.items.set(key, value);
+  }
+
+  removeItem(key) {
+    return this.items.delete(key);
+  }
+
+  key(i) {
+    return this.items.keys()[i];
+  }
+}
+
 class Storage {
-  constructor(engine) {
-    this.engine = engine;
+  constructor() {
+    try {
+      this.engine = localStorage || new Mem();
+    } catch (e) {
+      this.engine = new Mem();
+    }
   }
 
   get totalDownloads() {
@@ -57,10 +87,6 @@ class Storage {
 
   getFileById(id) {
     return this.engine.getItem(id);
-  }
-
-  has(property) {
-    return this.engine.hasOwnProperty(property);
   }
 
   remove(property) {

--- a/frontend/src/upload.js
+++ b/frontend/src/upload.js
@@ -9,7 +9,7 @@ const {
   ONE_DAY_IN_MS
 } = require('./utils');
 const Storage = require('./storage');
-const storage = new Storage(localStorage);
+const storage = new Storage();
 const metrics = require('./metrics');
 const progress = require('./progress');
 


### PR DESCRIPTION
In Firefox when cookies are disabled so is localStorage. The current version 1.1.0 is completely unusable when this is set and I've noticed a few related errors on sentry. 

This PR makes uploading and downloading work, but the file list (as expected) does not.