### PR TITLE
Fixed minimum NodeJS version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A file sharing experiment which allows you to send encrypted files to other user
 
 ## Requirements
 
-- [Node.js 8+](https://nodejs.org/)
+- [Node.js 8.2+](https://nodejs.org/)
 - [Redis server](https://redis.io/)
 
 **NOTE:** To run the project, make sure you have a Redis server running locally:


### PR DESCRIPTION
NodeJS version was increased to 8.2 due to possible http header splitting vulnerability
See: [https://github.com/mozilla/send/pull/469](https://github.com/mozilla/send/pull/469)