### PR TITLE
align the "Password" and "Copy to clipboard" fields.

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -652,7 +652,7 @@ tbody {
   display: flex;
   flex-wrap: nowrap;
   width: 80%;
-  padding: 10px 20px;
+  padding: 10px 5px;
 }
 
 /*    upload-error    */


### PR DESCRIPTION
the result of this css change: 

![screen shot 2017-10-20 at 4 22 34 pm](https://user-images.githubusercontent.com/10803178/31840355-fd29c9fe-b5b2-11e7-8fcf-baade2d1a42f.png)

Fixes: #594.