### PR TITLE
disable copying link when password not completed

### DIFF
--- a/app/templates/share.js
+++ b/app/templates/share.js
@@ -64,7 +64,9 @@ module.exports = function(state, emit) {
       );
       await delay(2000);
       input.disabled = false;
-      copyBtn.disabled = false;
+      if (!copyBtn.parentNode.classList.contains('wait-password')) {
+        copyBtn.disabled = false;
+      }
       copyBtn.classList.remove('success');
       copyBtn.textContent = state.translate('copyUrlFormButton');
     }

--- a/app/templates/share.js
+++ b/app/templates/share.js
@@ -57,6 +57,7 @@ module.exports = function(state, emit) {
       input.disabled = true;
       const copyBtn = document.getElementById('copy-btn');
       copyBtn.disabled = true;
+      copyBtn.classList.add('success');
       copyBtn.replaceChild(
         html`<img src="${assets.get('check-16.svg')}" class="icon-check">`,
         copyBtn.firstChild
@@ -64,6 +65,7 @@ module.exports = function(state, emit) {
       await delay(2000);
       input.disabled = false;
       copyBtn.disabled = false;
+      copyBtn.classList.remove('success');
       copyBtn.textContent = state.translate('copyUrlFormButton');
     }
   }

--- a/app/templates/uploadPassword.js
+++ b/app/templates/uploadPassword.js
@@ -21,14 +21,20 @@ module.exports = function(state, emit) {
     </form>
   </div>`;
 
-  function togglePasswordInput() {
+  function togglePasswordInput(e) {
     document.querySelector('.setPassword').classList.toggle('hidden');
+    document
+      .getElementById('copy')
+      .classList.toggle('wait-password', e.target.checked);
+    document.getElementById('copy-btn').disabled = e.target.checked;
   }
 
   function setPassword(event) {
     event.preventDefault();
     const password = document.getElementById('unlock-input').value;
     if (password.length > 0) {
+      document.getElementById('copy').classList.remove('wait-password');
+      document.getElementById('copy-btn').disabled = false;
       emit('password', { password, file });
     }
   }

--- a/app/templates/uploadPassword.js
+++ b/app/templates/uploadPassword.js
@@ -22,13 +22,17 @@ module.exports = function(state, emit) {
   </div>`;
 
   function togglePasswordInput(e) {
+    const unlockInput = document.getElementById('unlock-input');
+    const boxChecked = e.target.checked;
     document.querySelector('.setPassword').classList.toggle('hidden');
     document
       .getElementById('copy')
-      .classList.toggle('wait-password', e.target.checked);
-    document.getElementById('copy-btn').disabled = e.target.checked;
-    if (e.target.checked) {
-      document.getElementById('unlock-input').focus();
+      .classList.toggle('wait-password', boxChecked);
+    document.getElementById('copy-btn').disabled = boxChecked;
+    if (boxChecked) {
+      unlockInput.focus();
+    } else {
+      unlockInput.value = '';
     }
   }
 

--- a/app/templates/uploadPassword.js
+++ b/app/templates/uploadPassword.js
@@ -27,6 +27,9 @@ module.exports = function(state, emit) {
       .getElementById('copy')
       .classList.toggle('wait-password', e.target.checked);
     document.getElementById('copy-btn').disabled = e.target.checked;
+    if (e.target.checked) {
+      document.getElementById('unlock-input').focus();
+    }
   }
 
   function setPassword(event) {

--- a/assets/main.css
+++ b/assets/main.css
@@ -553,6 +553,11 @@ tbody {
   width: 100%;
 }
 
+#copy.wait-password #link,
+#copy.wait-password #copy-btn {
+  opacity: 0.5;
+}
+
 #copy-text {
   align-self: flex-start;
   margin-top: 60px;
@@ -596,13 +601,16 @@ tbody {
   white-space: nowrap;
 }
 
-#copy-btn:hover {
+#copy-btn:not(:disabled):hover {
   background-color: #0287e8;
 }
 
-#copy-btn:disabled {
+#copy-btn.success {
   background: #05a700;
   border: 1px solid #05a700;
+}
+
+#copy-btn:disabled {
   cursor: auto;
 }
 


### PR DESCRIPTION
select require password, the link and "copy" button get half opacity, and the button is disabled. When the checkbox is deselected or password is submitted the opacity is restored, and button is enabled.

result: 

![screen shot 2017-10-23 at 9 55 59 am](https://user-images.githubusercontent.com/10803178/31893075-8d3d502a-b7d8-11e7-9880-a98e2c1cf16c.png)


Fixes: #606.
Fixes: #600.
Related: #587.