### PR TITLE
allow drag and drop if navigating from shared page

### DIFF
--- a/app/fileManager.js
+++ b/app/fileManager.js
@@ -213,6 +213,7 @@ export default function(state, emitter) {
       await fadeOut('download-progress');
       saveFile(f);
       state.storage.totalDownloads += 1;
+      state.transfer = null;
       metrics.completedDownload({ size, time, speed });
       emitter.emit('pushState', '/completed');
     } catch (err) {


### PR DESCRIPTION
the `state.transfer` needs to be reset after the download as well, otherwise the check
`if (state.route === '/' && !state.transfer) {` in dragManager will fail.

Fixes: #584.