### PR TITLE
set a default MIME type in file metadata

### DIFF
--- a/app/fileSender.js
+++ b/app/fileSender.js
@@ -194,7 +194,7 @@ export default class FileSender extends Nanobus {
         JSON.stringify({
           iv: arrayToB64(this.iv),
           name: this.file.name,
-          type: this.file.type
+          type: this.file.type || 'application/octet-stream'
         })
       )
     );


### PR DESCRIPTION
fixes #620 

Summary: file.type can be empty (such as when the filename has no extension) , provide a default value to use should this happen when collecting the file metadata