### PR TITLE
Keyboard navigation/visual feedback regression

### DIFF
--- a/app/templates/welcome.js
+++ b/app/templates/welcome.js
@@ -23,17 +23,17 @@ module.exports = function(state, emit) {
       <span id="file-size-msg">
         <em>${state.translate('uploadPageSizeMessage')}</em>
       </span>
-      <label for="file-upload"
-        id="browse"
-        class="btn browse"
-        title="${state.translate('uploadPageBrowseButton1')}">
-        ${state.translate('uploadPageBrowseButton1')}</label>
       <input id="file-upload"
         type="file"
         name="fileUploaded"
         onfocus=${onfocus}
         onblur=${onblur}
         onchange=${upload} />
+      <label for="file-upload"
+        id="browse"
+        class="btn browse"
+        title="${state.translate('uploadPageBrowseButton1')}">
+        ${state.translate('uploadPageBrowseButton1')}</label>
     </div>
     ${fileList(state, emit)}
   </div>


### PR DESCRIPTION
My changes from #574 require the form to be ordered unusually to [apply a outline with CSS](https://github.com/mozilla/send/blob/bd5cdc52f9f979a6f88d35e983cdbd108cf550f2/assets/main.css#L276) when it has keyboard focus.

The ordering of the from was switched back in [this commit ](https://github.com/mozilla/send/commit/bc24a069da62af39efdb3f283ce1d9129ba0598e#diff-60ead385e7fcc0298db5058140959aa0L21) and the outline on keyboard focus was lost / stopped working.

This PR switches the order of the forms input and label elements back again, so that an outline will be shown when the upload button has keyboard focus.