### PR TITLE
#609 share interface: align text in input and button

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -600,6 +600,7 @@ tbody {
   color: white;
   cursor: pointer;
   font-size: 15px;
+  padding-bottom: 4px;
   padding-left: 10px;
   padding-right: 10px;
   white-space: nowrap;
@@ -840,6 +841,7 @@ tbody {
   color: white;
   cursor: pointer;
   font-size: 15px;
+  padding-bottom: 3px;
   padding-left: 10px;
   padding-right: 10px;
   white-space: nowrap;


### PR DESCRIPTION
Bug ([#609](https://github.com/mozilla/send/issues/609)): Text in input and button are not aligned on the middle axis

Fix: Add `padding-bottom` on the button elements to push their contents a bit higher
<img width="662" alt="Send’s share interface with middle aligned content in inputs and button" src="https://user-images.githubusercontent.com/7645967/33146737-b5d690be-cfc5-11e7-82f5-1ec55da9203d.png">
