### PR TITLE
#634: overwrite appearance of password submit input

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -840,6 +840,9 @@ tbody {
   border: 1px solid #0297f8;
   color: white;
   cursor: pointer;
+
+  /* Force flat button look */
+  -webkit-appearance: none;
   font-size: 15px;
   padding-bottom: 3px;
   padding-left: 10px;


### PR DESCRIPTION
Bug: The button to set a password had a different look than other buttons on the site

Fix: add `-webkit-appearance: none` on the input element to force browser to discard the default styling. For a reduced test case demonstrating the fix see https://codepen.io/ovl/full/qVYgoO/