### PR TITLE
stop drag target from flickering when dragging over children

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -236,6 +236,10 @@ a {
   text-align: center;
 }
 
+.upload-window.ondrag * {
+  pointer-events: none;
+}
+
 .link {
   color: #0094fb;
   text-decoration: none;


### PR DESCRIPTION

![dec-08-2017 10-49-56](https://user-images.githubusercontent.com/10803178/33773345-94629f26-dc05-11e7-8e78-88ef65ad6d24.gif)


- removed mouse events from child element when dragging is happening.