### PR TITLE
Make develop the default NODE_ENV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,5 @@ services:
       - "1443:1443"
     environment:
       - REDIS_HOST=redis
-      - NODE_ENV=production
   redis:
     image: redis:alpine


### PR DESCRIPTION
This fixes https://github.com/mozilla/send/issues/666 by not assuming production in the docker-compose.yml.

**Important Note:** before deploying this, please make sure the production infrastructure actually sets the NODE_ENV variable as this could pose a production => development node env regression if not.