### PR TITLE
Use EXPIRE_SECONDS to calculate file ttl for static content

### DIFF
--- a/app/templates/share.js
+++ b/app/templates/share.js
@@ -1,3 +1,4 @@
+/* global EXPIRE_SECONDS */
 const html = require('choo/html');
 const assets = require('../../common/assets');
 const notFound = require('./notFound');
@@ -16,10 +17,11 @@ function passwordComplete(state, password) {
 }
 
 function expireInfo(file, translate, emit) {
+  const hours = Math.floor(EXPIRE_SECONDS / 60 / 60);
   const el = html([
     `<div>${translate('expireInfo', {
       downloadCount: '<select></select>',
-      timespan: translate('timespanHours', { num: 24 })
+      timespan: translate('timespanHours', { num: hours })
     })}</div>`
   ]);
   const select = el.querySelector('select');


### PR DESCRIPTION
This resolves #671 

- Calculate hours from the global variable `EXPIRE_SECONDS`
- Use the calculated value to specify the file ttl on the share page

![screenshot-2017-12-13 firefox send 1](https://user-images.githubusercontent.com/828329/33972538-22fd1794-e033-11e7-96b1-4bc36740d310.png)
