### PR TITLE
Mask password on upload

### DIFF
--- a/app/templates/uploadPassword.js
+++ b/app/templates/uploadPassword.js
@@ -13,6 +13,7 @@ module.exports = function(state, emit) {
     </div>
     <form class="setPassword hidden" onsubmit=${setPassword} data-no-csrf>
       <input id="unlock-input"
+        type="password"
         class="unlock-input input-no-btn"
         maxlength="64"
         autocomplete="off"


### PR DESCRIPTION
When a user enters a password for a given file download, mask it so it doesn't show to someone looking over their shoulder.  I also briefly looked into how to mask the echo'd password, which comes out in pre tags, but would love some advice on how to approach that.  Advice is welcomed!