### PR TITLE
Show Warning, Cancel and Redirect on size > 2GB ; fixes #578

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.idea

--- a/app/templates/welcome.js
+++ b/app/templates/welcome.js
@@ -1,7 +1,8 @@
+/* global MAXFILESIZE */
 const html = require('choo/html');
 const assets = require('../../common/assets');
 const fileList = require('./fileList');
-const { fadeOut } = require('../utils');
+const { bytes, fadeOut } = require('../utils');
 
 module.exports = function(state, emit) {
   const div = html`
@@ -64,6 +65,11 @@ module.exports = function(state, emit) {
     if (file.size === 0) {
       return;
     }
+    if (file.size > MAXFILESIZE) {
+      window.alert(state.translate('fileTooBig', { size: bytes(MAXFILESIZE) }));
+      return;
+    }
+
     await fadeOut('page-one');
     emit('upload', { file, type: 'click' });
   }


### PR DESCRIPTION
As mentioned by @SoftVision-CosminMuntean and @johngruen at #578, this PR resolves issues related to file uploads of sizes > 2GB. It displays the warning message, cancels the upload and further redirects back to the home page. 

The following preview has been generated for file sizes > 200MB as my laptop crashes for any file having size > 1 GB. However, this limit can be very easily altered as per our needs.

Here is the preview (its a gif file so please be patient while it loads)

![filesize](https://user-images.githubusercontent.com/25258877/34531167-781555ac-f0d7-11e7-8450-a55a78e1df73.gif)

@dannycoates @SoftVision-CosminMuntean @johngruen Please review and suggest changes.
  
  