### PR TITLE
improved popup for mobile display; Fixes #699

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1181,4 +1181,12 @@ tbody {
     font-size: 13px;
     padding: 17px 5px 0;
   }
+
+  .popup .popuptext::after {
+    left: 125px;
+  }
+
+  #deletePopup {
+    left: 83px;
+  }
 }


### PR DESCRIPTION
As suggested by @SoftVision-CiprianMuresan at #699, the popup for mobile view has been centered and thus now falls in the visible window. Here's a preview

![popup](https://user-images.githubusercontent.com/25258877/34807323-2148346a-f6ae-11e7-88e6-b8fadf484f67.gif)


Please review