### PR TITLE
send another file link now present on something went wrong page : Fixes #547 

### DIFF
--- a/app/templates/error.js
+++ b/app/templates/error.js
@@ -6,5 +6,8 @@ module.exports = function(state) {
   <div id="upload-error">
     <div class="title">${state.translate('errorPageHeader')}</div>
     <img id="upload-error-img" src="${assets.get('illustration_error.svg')}"/>
+    <a class="send-new"
+     href="/"
+     data-state="completed">${state.translate('sendAnotherFileLink')}</a>
   </div>`;
 };


### PR DESCRIPTION
As mentioned by @SoftVision-CiprianMuresan on #547, the changes have been made and the link is now visible on `something went wrong page`. 

Here's a preview 
![screenshot from 2018-01-24 08-09-53](https://user-images.githubusercontent.com/25258877/35311892-f40e1966-00de-11e8-879f-eb1c6808069a.png)

@dannycoates Please review