### PR TITLE
Don't translate URL-safe chars, b64 is doing it for us

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -9,10 +9,9 @@ function arrayToB64(array) {
 }
 
 function b64ToArray(str) {
-  str = (str + '==='.slice((str.length + 3) % 4))
-    .replace(/-/g, '+')
-    .replace(/_/g, '/');
-  return b64.toByteArray(str);
+  return b64.toByteArray(
+    str + '==='.slice((str.length + 3) % 4)
+  );
 }
 
 function loadShim(polyfill) {


### PR DESCRIPTION
Send should not translate URL-safe characters to their non-safe variant when decoding a base64 string, as [`base64-js`](https://github.com/beatgammit/base64-js) is already doing that for us. The library seems to be doing it in a more performant manner, therefore I removed the manual translation from Send in this PR.

See the following snippet in the `base64-js` library:
https://github.com/beatgammit/base64-js/blob/master/index.js#L17-L20

