### PR TITLE
Upgrade to fluent 0.8

### DIFF
--- a/build/fluent_loader.js
+++ b/build/fluent_loader.js
@@ -1,7 +1,7 @@
 // TODO: when node supports 'for await' we can remove babel-polyfill
 // and use 'fluent' instead of 'fluent/compat' (also below near line 42)
 require('babel-polyfill');
-const { MessageContext } = require('fluent/compat');
+const { FluentBundle } = require('fluent/compat');
 const fs = require('fs');
 
 function toJSON(map) {
@@ -29,10 +29,10 @@ module.exports = function(source) {
     require.resolve('../public/locales/en-US/send.ftl'),
     'utf8'
   );
-  const en = new MessageContext('en-US');
+  const en = new FluentBundle('en-US');
   en.addMessages(en_ftl);
   // pre-parse the ftl
-  const context = new MessageContext(locale);
+  const context = new FluentBundle(locale);
   context.addMessages(source);
 
   const merged = merge(en._messages, context._messages);
@@ -43,14 +43,14 @@ if (typeof window === 'undefined') {
   var fluent = require('fluent/compat');
 }
 (function () {
-  var ctx = new fluent.MessageContext('${locale}', {useIsolating: false});
-  ctx._messages = new Map(${toJSON(merged)});
+  var bundle = new fluent.FluentBundle('${locale}', {useIsolating: false});
+  bundle._messages = new Map(${toJSON(merged)});
   function translate(id, data) {
-    var msg = ctx.getMessage(id);
+    var msg = bundle.getMessage(id);
     if (typeof(msg) !== 'string' && !msg.val && msg.attrs) {
       msg = msg.attrs.title || msg.attrs.alt
     }
-    return ctx.format(msg, data);
+    return bundle.format(msg, data);
   }
   if (typeof window === 'undefined') {
     module.exports = translate;

--- a/build/fluent_loader.js
+++ b/build/fluent_loader.js
@@ -1,7 +1,4 @@
-// TODO: when node supports 'for await' we can remove babel-polyfill
-// and use 'fluent' instead of 'fluent/compat' (also below near line 42)
-require('babel-polyfill');
-const { FluentBundle } = require('fluent/compat');
+const { FluentBundle } = require('fluent');
 const fs = require('fs');
 
 function toJSON(map) {
@@ -39,8 +36,7 @@ module.exports = function(source) {
   return `
 module.exports = \`
 if (typeof window === 'undefined') {
-  require('babel-polyfill');
-  var fluent = require('fluent/compat');
+  var fluent = require('fluent');
 }
 (function () {
   var bundle = new fluent.FluentBundle('${locale}', {useIsolating: false});

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -14,7 +14,7 @@ The development environment includes all locales in `public/locales` via the `L1
 
 ## Code
 
-In `app/` we use the `state.translate()` function to translate strings to the best matching language base on the user's `Accept-Language` header. It's a wrapper around fluent's [MessageContext.format](http://projectfluent.org/fluent.js/fluent/MessageContext.html). It works the same for both server and client side rendering.
+In `app/` we use the `state.translate()` function to translate strings to the best matching language base on the user's `Accept-Language` header. It's a wrapper around fluent's [FluentBundle.format](http://projectfluent.org/fluent.js/fluent/FluentBundle.html). It works the same for both server and client side rendering.
 
 ### Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4706,9 +4706,9 @@
       "dev": true
     },
     "fluent": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.6.3.tgz",
-      "integrity": "sha512-NQS729z/Pza0b8LwKAy6IyJNNfZk1pcYoLFvTDXTkRfJEKShDNRRpgB7DS4rsf/iIDBJG6c51XgnOEMXAcEaZg=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.8.0.tgz",
+      "integrity": "sha512-bZfthhubEH1lKgGIi0fIDeNkZrfEOu3MrLbi284LdxNG+9Q5gq2KsuoocumqNPStVtWo3S3/1p8RIqd34u3Mzw=="
     },
     "fluent-intl-polyfill": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "connect-busboy": "0.0.2",
     "convict": "^4.0.1",
     "express": "^4.16.2",
-    "fluent": "^0.6.3",
+    "fluent": "^0.8.0",
     "fluent-langneg": "^0.1.0",
     "helmet": "^3.12.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
   },
   "dependencies": {
     "aws-sdk": "^2.251.1",
-    "babel-polyfill": "^6.26.0",
     "choo": "^6.10.0",
     "cldr-core": "^32.0.0",
     "connect-busboy": "0.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,9 +13,9 @@ const regularJSOptions = {
 };
 
 const entry = {
-  // babel-polyfill and fluent are directly included in vendor
-  // because they are not explicitly referenced by app
-  vendor: ['babel-polyfill', 'fluent'],
+  // fluent is directly included in vendor because it is not explicitly
+  // referenced by app
+  vendor: ['fluent'],
   app: ['./app/main.js'],
   style: ['./app/main.css']
 };


### PR DESCRIPTION
`fluent` 0.8.0 is out and it ships without the code which required `babel-polyfill`.