### PR TITLE
Use FluentResource to parse and serialize FTL files server-side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6675,9 +6675,9 @@
       "dev": true
     },
     "fluent": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.8.0.tgz",
-      "integrity": "sha512-bZfthhubEH1lKgGIi0fIDeNkZrfEOu3MrLbi284LdxNG+9Q5gq2KsuoocumqNPStVtWo3S3/1p8RIqd34u3Mzw=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.8.1.tgz",
+      "integrity": "sha512-hVlyzl3N9okoqqQUd6cExsBAOmxBeaxP3JFmBBPkYqSRQs4d2U2y2a5KxwMSvno1m9nmwM4CsjeBWdJ9wSYWsA=="
     },
     "fluent-intl-polyfill": {
       "version": "0.1.0",
@@ -6686,13 +6686,6 @@
       "dev": true,
       "requires": {
         "intl-pluralrules": "github:projectfluent/IntlPluralRules#94cb0fa1c23ad943bc5aafef43cea132fa51d68b"
-      },
-      "dependencies": {
-        "intl-pluralrules": {
-          "version": "github:projectfluent/IntlPluralRules#94cb0fa1c23ad943bc5aafef43cea132fa51d68b",
-          "from": "github:projectfluent/IntlPluralRules#module",
-          "dev": true
-        }
       }
     },
     "fluent-langneg": {
@@ -8186,6 +8179,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "intl-pluralrules": {
+      "version": "github:projectfluent/IntlPluralRules#94cb0fa1c23ad943bc5aafef43cea132fa51d68b",
+      "from": "github:projectfluent/IntlPluralRules#module",
       "dev": true
     },
     "invariant": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "convict": "^4.4.0",
     "express": "^4.16.3",
     "express-ws": "^4.0.0",
-    "fluent": "^0.8.0",
+    "fluent": "^0.8.1",
     "fluent-langneg": "^0.1.0",
     "helmet": "^3.13.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
The `_messages` property of `FluentBundle` is considered internal and I'd like to suggest to move Send away from using it. I don't want to make any guarantees that this internal API won't change in a minor release of `fluent`. `FluentResource` is a new public API which can be used to parse, cache and serialize FTL files.

Fixes #611.