### PR TITLE
Make file download limit changeable in config

### DIFF
--- a/app/pages/share/index.js
+++ b/app/pages/share/index.js
@@ -1,4 +1,6 @@
 /* global EXPIRE_SECONDS */
+/* global EXPIRE_LIMIT */
+
 const html = require('choo/html');
 const raw = require('choo/html/raw');
 const assets = require('../../../common/assets');
@@ -104,7 +106,7 @@ function expireInfo(file, translate, emit) {
     })
   )}</div>`;
   const select = el.querySelector('select');
-  const options = [1, 2, 3, 4, 5, 20].filter(i => i > (file.dtotal || 0));
+  const options = EXPIRE_LIMIT.filter(i => i > (file.dtotal || 0));
   const t = num => translate('downloadCount', { num });
   const changed = value => emit('changeLimit', { file, value });
   el.replaceChild(selectbox(file.dlimit || 1, options, t, changed), select);

--- a/server/config.js
+++ b/server/config.js
@@ -60,6 +60,11 @@ const conf = convict({
     default: 86400,
     env: 'EXPIRE_SECONDS'
   },
+  expire_limit: {
+    format: Array,
+    default: [1, 2, 3, 4, 5, 20],
+    env: 'EXPIRE_LIMIT'
+  },
   l10n_dev: {
     format: Boolean,
     default: false,

--- a/server/routes/jsconfig.js
+++ b/server/routes/jsconfig.js
@@ -36,6 +36,7 @@ if (isIE && !isUnsupportedPage) {
 }
 var MAXFILESIZE = ${config.max_file_size};
 var EXPIRE_SECONDS = ${config.expire_seconds};
+var EXPIRE_LIMIT = [${config.expire_limit}];
 ${ga}
 ${sentry}
 `;

--- a/server/routes/params.js
+++ b/server/routes/params.js
@@ -1,8 +1,11 @@
 const storage = require('../storage');
+const config = require('../config');
 
 module.exports = function(req, res) {
   const dlimit = req.body.dlimit;
-  if (!dlimit || dlimit > 20) {
+  const expire_limit = [config.expire_limit];
+  const expire_max = expire_limit[expire_limit.length - 1];
+  if (!dlimit || dlimit > expire_max) {
     return res.sendStatus(400);
   }
 


### PR DESCRIPTION
We're testing using Send internally, and needed to customise a few parameters to make it more suitable: 

Finding ```expire_config``` in **config.js** was logical and easy, but increasing the download limit options meant going to **app/pages/share/index.js** to change the options variable, and then **server/routes/params.js** to make the server accept anything above 20. 

**N.B. I'm really not much of a Node guy, so I expect some tests might not work**