### PR TITLE
Fixes #1037: Fix back button crasher

### DIFF
--- a/android/app/src/main/java/org/mozilla/sendandroid/MainActivity.kt
+++ b/android/app/src/main/java/org/mozilla/sendandroid/MainActivity.kt
@@ -127,7 +127,7 @@ class MainActivity : AppCompatActivity(), AdvancedWebView.Listener {
         super.onDestroy()
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent) {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         super.onActivityResult(requestCode, resultCode, intent)
         mWebView!!.onActivityResult(requestCode, resultCode, intent)
         // ...


### PR DESCRIPTION
Java has nulls, and any object reference in Java can be null, but in Kotlin parameters default to not null unless the type is specified as `Type?`; our override of onActivityResult was specifying the type of the intent parameter as `Intent` instead of `Intent?`, causing an exception before our code was called. Figuring out how to turn on "break on all exceptions" in Android Studio (which is non-trivial for some reason) finally showed me the stack trace.