### PR TITLE
Fix function to calculate encrypted ECE ciphertext length

### DIFF
--- a/app/ece.js
+++ b/app/ece.js
@@ -282,7 +282,8 @@ class StreamSlicer {
 }
 
 export function encryptedSize(size, rs = ECE_RECORD_SIZE) {
-  return 21 + size + 16 * Math.floor(size / (rs - 17));
+  const chunk_meta = TAG_LENGTH + 1; // Chunk metadata, tag and delimiter
+  return 21 + size + chunk_meta * Math.ceil(size / (rs - chunk_meta));
 }
 
 /*


### PR DESCRIPTION
I figured the current implementation of `encryptedSize` was wrong for Send v2, this PR fixes the it.

Used available constants instead of hard coded numbers where possible.

Explanation:
- `16` was used as overhead per chunk, should be `17` as it also includes a padding delimiter. Simplified to `chunk_meta` constant.
- `floor` was used to determine chunk count, must be `ceil` to include last partially filled chunk (which also includes a tag and delimiter).

Note: the CircleCI `test` stage failed, but this does not seem to be caused by this PR.