### PR TITLE
1149-fix-aborted-event-gt-node-v9.x.x

### DIFF
--- a/server/routes/download.js
+++ b/server/routes/download.js
@@ -9,7 +9,7 @@ module.exports = async function(req, res) {
     const file_stream = storage.get(id);
     let cancelled = false;
 
-    req.on('close', () => {
+    req.on('aborted', () => {
       cancelled = true;
       file_stream.destroy();
     });

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -41,7 +41,7 @@ module.exports = function(req, res) {
     }
   });
 
-  req.on('close', async err => {
+  req.on('aborted', async err => {
     try {
       await storage.del(newId);
     } catch (e) {


### PR DESCRIPTION
Resolves #1149.

Use `aborted` rather than `close` event for detecting when the client has cancelled the upload or download requests.

Note: Broken with node `> v11.0.0`, resolved in node `v11.10.1`