### PR TITLE
Fix link to dev.js and prod.js files.

### DIFF
--- a/server/readme.md
+++ b/server/readme.md
@@ -1,6 +1,6 @@
 # Server Code
 
-The server provides the API, serves static assets, and renders the pages for Send. The production entrypoint is [prod.js](./prod.js) and the development entrypoint is [dev.js](./dev.js) via `webpack-dev-server`.
+The server provides the API, serves static assets, and renders the pages for Send. The production entrypoint is [prod.js](./bin/prod.js) and the development entrypoint is [dev.js](./bin/dev.js) via `webpack-dev-server`.
 
 ## Server configuration
 


### PR DESCRIPTION
The links on readme.md were pointing to no longer existent files. With this PR these links are updated to the new location of the files inside the ./bin directory.