### PR TITLE
Issue: Signup Modal closing upon clicking on the white space above the input box

### DIFF
--- a/app/main.css
+++ b/app/main.css
@@ -169,6 +169,10 @@ footer li:hover {
   flex-shrink: 0;
 }
 
+.firefox-signup-logo {
+  margin-bottom: 130px;
+}
+
 #password-msg::after {
   content: '\200b';
 }
@@ -287,4 +291,11 @@ select {
 
 .word-break-all {
   word-break: break-all;
+}
+
+@media screen and (max-width: 768px) {
+  .firefox-signup-logo {
+    margin-bottom: 0;
+    margin-top: 90px;
+  }
 }

--- a/app/ui/modal.js
+++ b/app/ui/modal.js
@@ -9,7 +9,7 @@ module.exports = function(state, emit) {
       <div
         class="h-full w-full max-h-screen absolute pin-t flex items-center justify-center"
       >
-        <div class="w-full" onclick="${e => e.stopPropagation()}">
+        <div class="w-full h-full" onclick="${e => e.stopPropagation()}">
           ${state.modal(state, emit, close)}
         </div>
       </div>

--- a/app/ui/signupDialog.js
+++ b/app/ui/signupDialog.js
@@ -12,10 +12,14 @@ module.exports = function(trigger) {
       <send-signup-dialog
         class="flex flex-col lg:flex-row justify-center px-8 md:px-24 w-full h-full"
       >
-        <img
-          src="${assets.get('firefox_logo-only.svg')}"
-          class="h-16 mt-1 mb-4"
-        />
+        <section
+          class="flex flex-col flex-no-shrink self-center firefox-signup-logo"
+        >
+          <img
+            src="${assets.get('firefox_logo-only.svg')}"
+            class="h-16 mt-1 mb-4"
+          />
+        </section>
         <section
           class="flex flex-col flex-no-shrink self-center lg:mx-6 lg:max-w-xs"
         >


### PR DESCRIPTION
Issue: Signup Modal closing upon clicking on the white space around the text or input box
Solution: Added Styling and respective classes to make it full height for the container

Demo:
![demo](https://user-images.githubusercontent.com/4560500/54678411-1c2e8b00-4b2b-11e9-9d2c-8155ae22201c.gif)
