### PR TITLE
Prevent possible download counter race condition

### DIFF
--- a/server/routes/download.js
+++ b/server/routes/download.js
@@ -34,7 +34,7 @@ module.exports = async function(req, res) {
         if (dl >= dlimit) {
           await storage.del(id);
         } else {
-          await storage.setField(id, 'dl', dl);
+          await storage.incrementField(id, 'dl');
         }
       } catch (e) {
         log.info('StorageError:', id);

--- a/server/storage/index.js
+++ b/server/storage/index.js
@@ -62,6 +62,10 @@ class DB {
     this.redis.hset(id, key, value);
   }
 
+  incrementField(id, key, increment = 1) {
+    this.redis.hincrby(id, key, increment);
+  }
+
   async del(id) {
     const filePath = await this.getPrefixedId(id);
     this.storage.del(filePath);


### PR DESCRIPTION
This very small change leverages the _hincrby_ function of Redis instead of setting the download count manually. Even though it would be very rare, it could lead to a race condition where multiple requests will set the same download count which causes it be counted as just 1 download.