### PR TITLE
Defined retry_strategy for redis. Closes #1292

### DIFF
--- a/server/storage/redis.js
+++ b/server/storage/redis.js
@@ -10,7 +10,14 @@ module.exports = function(config) {
   const redis = require(redis_lib);
   const client = redis.createClient({
     host: config.redis_host,
-    connect_timeout: 10000
+    retry_strategy: options => {
+      if (options.total_retry_time > 10000) {
+        client.emit('error', 'Retry time exhausted');
+        return new Error('Retry time exhausted');
+      }
+
+      return 500;
+    }
   });
 
   client.ttlAsync = promisify(client.ttl);


### PR DESCRIPTION
Removed deprecated connect_timeout.
Added a new retry_strategy. Retries every 500ms and emits and error to be caught at the 10 seconds limit.
`client.emit` was added since there is a handler for error on storage/index.js. Since returning the error does not throw it (NodeRedis/node_redis#1113)