### PR TITLE
Improving Dockerfile WIP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,8 @@
-# All hidden files
-./.*
-
 # Dirs
 node_modules/
-firefox/
-assets/
-docs/
-test/
-coverage/
 dist/
+.*/
+!.git/
 
 # Files
 Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,18 @@
-node_modules
-.git
-.tox
-.DS_Store
-firefox
-assets
-docs
-test
-coverage
-.nyc_output
+# All hidden files
+./.*
+
+# Dirs
+node_modules/
+firefox/
+assets/
+docs/
+test/
+coverage/
+dist/
+
+# Files
+Dockerfile
+CONTRIBUTORS
+CODE_OF_CONDUCT.md
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,17 @@ COPY . /app/
 WORKDIR /app
 RUN set -x \
     # Build
-    && rm -f package-lock.json \
     && npm install \
-    && npm run build \
-    # Delete 'node_modules' dir
-    && rm -rf node_modules
+    && npm run build
+USER root
+RUN set -x \
+    # Delete useless dirs
+    && rm -rf \
+        node_modules \
+        .git \
+        android \
+        ios \
+        test
 
 
 # Download prod dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,74 @@
+##
+# Firefox Send - Mozilla
+#
+# License https://github.com/mozilla/send/blob/master/LICENSE
+##
+
+
+# Build project
 FROM node:10 AS builder
-RUN addgroup --gid 10001 app && adduser --disabled-password --gecos '' --gid 10001 --home /app --uid 10001 app
+RUN set -x \
+    # Add user
+    && addgroup --gid 10001 app \
+    && adduser --disabled-password \
+        --gecos '' \
+        --gid 10001 \
+        --home /app \
+        --uid 10001 \
+        app \
+    # Install system dependencies
+    && npm install rimraf -g
+USER app
+COPY . /app/
+WORKDIR /app
+RUN set -x \
+    # Build
+    && rm -f package-lock.json \
+    && npm install \
+    && npm run build \
+    # Delete 'node_modules' dir
+    && rm -rf node_modules
+
+
+# Download prod dependencies
+FROM node:10 AS prod-dependencies
+RUN set -x \
+    # Add user
+    && addgroup --gid 10001 app \
+    && adduser --disabled-password \
+        --gecos '' \
+        --gid 10001 \
+        --home /app \
+        --uid 10001 \
+        app \
+    # Install system dependencies
+    && npm install rimraf -g
 COPY package*.json /app/
 WORKDIR /app
 RUN npm install --production
 
+
+# Main image
 FROM node:10-slim
-RUN addgroup --gid 10001 app && adduser --disabled-password --gecos '' --gid 10001 --home /app --uid 10001 app
-USER app
 WORKDIR /app
-COPY --chown=app:app --from=builder /app .
-COPY --chown=app:app . .
-RUN ln -s dist/version.json version.json
+COPY --chown=10001:10001 --from=builder /app .
+COPY --chown=10001:10001 --from=prod-dependencies /app/node_modules ./node_modules
+RUN set -x \
+    # Add user
+    && addgroup --gid 10001 app \
+    && adduser --disabled-password \
+        --gecos '' \
+        --gid 10001 \
+        --home /app \
+        --uid 10001 \
+        app \
+    # Fix permissions
+    && chown 10001.10001 .
+
+USER app
 
 ENV PORT=1443
-EXPOSE $PORT
+
+EXPOSE ${PORT}
 
 CMD ["node", "server/bin/prod.js"]


### PR DESCRIPTION
## Why

The current `Dockerfile` don't build everything that is necessary and also requires some caches from CircleCI.

I need a PC with NodeJS, install a ton of dependencies (some compatibilities issues can happen if I'm using Windows or Mac OS X), and build the `dist/` before building the container.

So I decided to change the `Dockerfile` and now this file has everything that's necessary to build the `Firefox Send`. In other words, a clean environment needs Docker and nothing more to build the project.

## How to use

```bash
git clone ${REPO_PATH_HERE} firefox-send
cd firefox-send
docker build -t ${IMAGE_TAG} .
```

## Advantages

- Now the Docker Hub can access the repo README.md file: https://cloud.docker.com/repository/docker/thenets/send/general

- The build log is available to everyone and doesn't need any kind of information from CircleCI: https://cloud.docker.com/repository/registry-1.docker.io/thenets/send/builds/2b407123-d773-4a76-b58d-f6346b98a997


## Problems

I don't know what is going on but the `node_modules` created by this new `Dockerfile` is bigger than the current Docker image (110MB). Maybe some developer can help me.

![image](https://user-images.githubusercontent.com/2138276/59966646-9b01de00-94f5-11e9-993e-b638e9ff212b.png)

## More infos

- With the new partial builder, it's possible to easily integrate unit-test with any CI apps and it's easy to integrate with environments that apply CI/CD like OpenShift Pipeline and GitLab CI/CD.

- I have no idea why the symbolic link to `version.json` was present in the old `Dockerfile`. Can someone explain to me if I need that file and why?

- I think that should be added information about the project and the maintainer email in the `Dockerfile`. More info here: https://docs.docker.com/engine/reference/builder/#label