### PR TITLE
Allow successful npm build without .git

### DIFF
--- a/build/version_plugin.js
+++ b/build/version_plugin.js
@@ -1,5 +1,13 @@
-const commit = require('git-rev-sync').short();
+const gitRevSync = require('git-rev-sync');
 const pkg = require('../package.json');
+
+let commit = 'unknown';
+
+try {
+  commit = gitRevSync.short();
+} catch (e) {
+  console.warn('Error fetching current git commit: ' + e);
+}
 
 const version = JSON.stringify({
   commit,


### PR DESCRIPTION
**Problem**: `npm run build` requires a `.git` directory with at least one commit to succeed. The build attempts to read the latest commit hash and write it to `version.json`, for use in the `__version__` route.

**Proposed solution**: If `.git` is missing or empty during npm build, log the error but allow the build to continue. `version.json` is still generated with the same format, but the value of `commit` is `unknown`.

**Rationale**:  Depending on the build process, `.git` may not be preserved in the source code for a variety of reasons. For example putting `.git` in `.dockerignore` is common to cut down on the number of files copied. The fetched git hash is not necessary for normal operation of the app, and only used for [debug/diagnostic purposes](https://github.com/mozilla/send/issues/33) (AFAIK). Therefore it shouldn't be be a hard dependency to build the app.

We've implemented this as a workaround in our build process, figured it might be more generally applicable to others. Feedback welcomed.