### PR TITLE
modify connect-src of Content Security Policy to include dynamic wss URL based on configured base URL

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -13,6 +13,7 @@ Run `docker build -t send:latest .` to create an image or `docker-compose up` to
 | `SENTRY_DSN` | Sentry DSN
 | `MAX_FILE_SIZE` | in bytes (defaults to 2147483648)
 | `NODE_ENV`       | "production"
+| `BASE_URL`       | The HTTPS URL where traffic will be served (e.g. `https://send.firefox.com`)
 
 ## Example:
 
@@ -22,5 +23,6 @@ $ docker run --net=host -e 'NODE_ENV=production' \
   -e 'REDIS_HOST=dyf9s2r4vo3.bolxr4.0001.usw2.cache.amazonaws.com' \
   -e 'SENTRY_CLIENT=https://51e23d7263e348a7a3b90a5357c61cb2@sentry.prod.mozaws.net/168' \
   -e 'SENTRY_DSN=https://51e23d7263e348a7a3b90a5357c61cb2:65e23d7263e348a7a3b90a5357c61c44@sentry.prod.mozaws.net/168' \
+  -e 'BASE_URL=https://send.firefox.com' \
   mozilla/send:latest
 ```

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -39,7 +39,7 @@ module.exports = function(app) {
             "'self'",
             'wss://*.dev.lcip.org',
             'wss://*.send.nonprod.cloudops.mozgcp.net',
-            'wss://send.firefox.com',
+            config.base_url.replace(/^https:\/\//, 'wss://'),
             'https://*.dev.lcip.org',
             'https://accounts.firefox.com',
             'https://*.accounts.firefox.com',


### PR DESCRIPTION
When serving Firefox Send from a domain of our own, uploads were failing on the following browsers:

- iOS Firefox
- iOS Chrome
- iOS Safari
- Mac Safari

This resolves the issue by generating a proper wss URL for the connect-src CSP directive. Since the default value of `base_url` in the config is `https://send.firefox.com`, the directive will be identical to its value before this change if the `BASE_URL` environment variable is not set