### PR TITLE
Handle Content-Security-Policy for self hosting FxA

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -145,6 +145,26 @@ const conf = convict({
     default: 'https://identity.mozilla.com/apps/send',
     env: 'FXA_KEY_SCOPE'
   },
+  fxa_csp_oauth_url: {
+    format: String,
+    default: '',
+    env: 'FXA_CSP_OAUTH_URL'
+  },
+  fxa_csp_content_url: {
+    format: String,
+    default: '',
+    env: 'FXA_CSP_CONTENT_URL'
+  },
+  fxa_csp_profile_url: {
+    format: String,
+    default: '',
+    env: 'FXA_CSP_PROFILE_URL'
+  },
+  fxa_csp_profileimage_url: {
+    format: String,
+    default: '',
+    env: 'FXA_CSP_PROFILEIMAGE_URL'
+  },
   survey_url: {
     format: String,
     default: '',

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -31,8 +31,7 @@ module.exports = function(app) {
     next();
   });
   if (!IS_DEV) {
-    app.use(
-      helmet.contentSecurityPolicy({
+    let csp = {
         directives: {
           defaultSrc: ["'self'"],
           connectSrc: [
@@ -62,9 +61,28 @@ module.exports = function(app) {
           objectSrc: ["'none'"],
           reportUri: '/__cspreport__'
         }
-      })
+      }
+
+    csp.directives.connectSrc.push(config.base_url.replace(/^https:\/\//,'wss://'))
+    if(config.fxa_csp_oauth_url != ""){
+      csp.directives.connectSrc.push(config.fxa_csp_oauth_url)
+    }
+    if(config.fxa_csp_content_url != "" ){
+      csp.directives.connectSrc.push(config.fxa_csp_content_url)
+    }
+    if(config.fxa_csp_profile_url != "" ){
+      csp.directives.connectSrc.push(config.fxa_csp_profile_url)
+    }
+    if(config.fxa_csp_profileimage_url != ""){
+      csp.directives.imgSrc.push(config.fxa_csp_profileimage_url)
+    }
+
+
+    app.use(
+      helmet.contentSecurityPolicy(csp)
     );
   }
+
   app.use(function(req, res, next) {
     res.set('Pragma', 'no-cache');
     res.set(


### PR DESCRIPTION
Handle Content-Security-Policy headers  for a self hosting FxA stack .

Related Issue : https://github.com/jackyzy823/fxa-selfhosting/issues/1#issuecomment-640233320