### PR TITLE
Use compat build of Fluent

### DIFF
--- a/app/locale.js
+++ b/app/locale.js
@@ -1,4 +1,4 @@
-import { FluentBundle } from '@fluent/bundle';
+import { FluentBundle } from '@fluent/bundle/compat';
 
 function makeBundle(locale, ftl) {
   const bundle = new FluentBundle(locale, { useIsolating: false });


### PR DESCRIPTION
Use compat build of fluent to support Edge older than 79.

See projectfluent/fluent.js#431 and mozilla-iot/gateway#2238

Fixes #1487 