### PR TITLE
Fixed a typo in ENCRYPTION.md

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,6 +1,6 @@
 # File Encryption
 
-Send use 128-bit AES-GCM encryption via the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) to encrypt files in the browser before uploading them to the server. The code is in [app/keychain.js](../app/keychain.js).
+Send uses 128-bit AES-GCM encryption via the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) to encrypt files in the browser before uploading them to the server. The code is in [app/keychain.js](../app/keychain.js).
 
 ## Steps
 


### PR DESCRIPTION
There was a typo in ENCRYPTION.md, "send use" should be "send uses"